### PR TITLE
Generalise `to_types`

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -61,7 +61,6 @@ to_factor <- function(df) {
   return(list(df = df, input_types = input_types))
 }
 
-# TODO: generalize this, not excluding factors
 #' Convert Data Frame Data to Provided Types
 #'
 #' @inheritParams to_factor
@@ -71,12 +70,12 @@ to_factor <- function(df) {
 #'
 #' @keywords internal
 to_types <- function(df, types) {
-  for (col in names(df)) {
-    if (col %in% names(types) && types[col] != "factor") {
-      df[[col]] <- do.call(paste0("as.", types[[col]]), list(df[[col]]))
-    }
-  }
-
+  df[names(types)] <- mapply(
+    \(t, x) get(sprintf("as.%s", t), mode = "function")(x),
+    types,
+    df[names(types)],
+    SIMPLIFY = FALSE
+  )
   return(df)
 }
 


### PR DESCRIPTION
Map dynamic `as.{TYPE}` calls via `get(sprintf("as.%s", TYPE), ...)`.  Generalises `to_types` to handle factors.

## Tests

I'm not yet familiar with `testthat`, please let me know if I should modify the following to suit.

```r
to_types <- function(df, types) {
  df[names(types)] <- mapply(
    \(t, x) get(sprintf("as.%s", t), mode = "function")(x),
    types, df[names(types)],
    SIMPLIFY = FALSE
  )
  return(df)
}

df <- data.frame(
  Index = seq.int(6L),
  Type = as.factor(
    c("x1", "x1", "x1", "x2", "x2", "x3")
  ),
  Tested = c("yes", "no", "no", "yes", "no", "no")
)

str(df)

str(to_types(df, list(Type = "character")))
str(to_types(df, list(Index = "factor", Tested = "factor")))
str(to_types(df, list(Index = "factor", Type = "character")))

str(to_types(
  df,
  list(Index = "factor", Type = "character", Tested = "factor")
))
```